### PR TITLE
Bugfix: Uniform size for all wallet cards

### DIFF
--- a/client-admin/src/components/Wallets/YourWallets/Cards.jsx
+++ b/client-admin/src/components/Wallets/YourWallets/Cards.jsx
@@ -166,6 +166,7 @@ function TotalCard({ received, invested }) {
 
 const walletStyles = makeStyles((theme) => ({
   wallet: {
+    minHeight: 301,
     backgroundColor: "#ffffff",
     fontFamily: '"Roboto", sans-serif',
     paddingTop: 10,


### PR DESCRIPTION
This sets a minimum height for all of the wallets tracked on the 'Your Wallet' page.

Actual:
![image](https://user-images.githubusercontent.com/6285466/83574582-c493f980-a4fb-11ea-9ffc-99c6076d7691.png)

Expected:
![image](https://user-images.githubusercontent.com/6285466/83574620-dd9caa80-a4fb-11ea-9b78-6313abdc2ec7.png)
