### PR TITLE
Wallet owners coutn on details page

### DIFF
--- a/client-admin/src/components/Wallets/WalletCards.jsx
+++ b/client-admin/src/components/Wallets/WalletCards.jsx
@@ -692,6 +692,8 @@ function WalletDetailsCard({
   feesUSD,
   address,
   exchangeRate,
+  isMultisig,
+  multisigOwners,
 }) {
   const classes = WalletDetailsCardStyles();
 
@@ -754,7 +756,6 @@ function WalletDetailsCard({
           <div className={classes.walletSubtitle}>Transaction Fees</div>
         </Grid>
       </Grid>
-
       <div className={classes.address}>
         {address}{" "}
         <Button
@@ -768,8 +769,12 @@ function WalletDetailsCard({
         </Button>
       </div>
       <div className={classes.walletSubtitle}>Wallet Address</div>
-      <div className={classes.owners}>You + 2 users</div>
-      <div className={classes.walletSubtitle}>Wallet Owners</div>
+      {isMultisig && (
+        <Fragment>
+          <div className={classes.owners}>{multisigOwners.length} users</div>
+          <div className={classes.walletSubtitle}>Wallet Owners</div>
+        </Fragment>
+      )}
     </div>
   );
 }

--- a/client-admin/src/components/Wallets/YourWallets/WalletDetails/index.jsx
+++ b/client-admin/src/components/Wallets/YourWallets/WalletDetails/index.jsx
@@ -72,6 +72,8 @@ export default function ({
         feesUSD={wallet.feesUSD}
         address={wallet.address}
         exchangeRate={exchangeRate}
+        isMultisig={wallet.isMultisig}
+        multisigOwners={wallet.multisigOwners}
       />
       <TransactionDetails
         address={address}


### PR DESCRIPTION
Adds Owner count to multisig wallets for wallet details. Hides multisig count on wallets that are not multisig.

1. Add a wallet, any wallet type. No multisig:
2. View that wallet's details:

ER:
![image](https://user-images.githubusercontent.com/6285466/85760337-bc387400-b6df-11ea-8b4e-271ef41a0868.png)

3. Add a multisig wallet, any type, any number of users
4. View details for that wallet

ER:
![image](https://user-images.githubusercontent.com/6285466/85760476-dffbba00-b6df-11ea-9d27-05cc86789302.png)

Count of multisig owners matches the bottom left on the details summary