### PR TITLE
BUGFIX: fix array refs when archiving transactions

### DIFF
--- a/admin/routes/private.js
+++ b/admin/routes/private.js
@@ -243,22 +243,21 @@ router.post("/natcom", async (req, res) => {
   res.send(natcom);
 });
 
-
 router.get("/prices", async (req, res) => {
   const juniperAdmin = req.app.get("juniperAdmin");
   const { params } = req.body;
   let prices = [];
 
-
-  console.log('params', params)
-
   try {
-    prices = await juniperAdmin.db.getPrices(params.symbol, params.timeStart, params.timeEnd);
+    prices = await juniperAdmin.db.getPrices(
+      params.symbol,
+      params.timeStart,
+      params.timeEnd
+    );
   } catch (e) {
     return logger.error(e);
   }
   res.json(prices);
 });
-
 
 module.exports = router;

--- a/client-admin/src/components/Transactions/index.jsx
+++ b/client-admin/src/components/Transactions/index.jsx
@@ -91,13 +91,15 @@ export default function Transactions({ getExchangeRate }) {
   };
 
   const archiveTransaction = (txid) => {
-    txs.forEach((tx) => {
+    const newTxs = txs.slice();
+
+    newTxs.forEach((tx) => {
       if (tx.txid === txid) {
         tx.archived = true;
       }
     });
-    setTxs(txs);
-    filterTransactions(txs);
+    setTxs(newTxs);
+    filterTransactions(newTxs);
   };
 
   const archiveTransactionSuccess = () => {
@@ -107,13 +109,14 @@ export default function Transactions({ getExchangeRate }) {
   };
 
   const archiveTransactionFailed = (txid) => {
-    txs.forEach((tx) => {
+    const newTxs = txs.slice();
+    newTxs.forEach((tx) => {
       if (tx.txid === txid) {
         tx.archived = false;
       }
     });
-    setTxs(txs);
-    filterTransactions(txs);
+    setTxs(newTxs);
+    filterTransactions(newTxs);
     setSnackbarMessage("Tx Archive Failed");
     setSnackbarSeverity("error");
     setShowSnackbar(true);
@@ -143,7 +146,7 @@ export default function Transactions({ getExchangeRate }) {
       }
 
       setTxs(txs);
-      filterTransactions(txs.splice(0, 10));
+      filterTransactions(txs);
       setFetchingTxs(false);
     };
 


### PR DESCRIPTION
On the last PR the transaction array was modifying the transactions stored in state. This is an anti-pattern in react and makes bad things happen, react can't track changes. 

When archiving a transaction this would cause bugs. The data was correctly processed on the backend but the front end was out of sync, multiple txs would disappear and no archived txs would show up.

To Test:

on develop branch clear db of wallets/transactions

1. Add Wallet: 0x61acE53098d226e77cd26AE26E2C377FB9cB7657
2. Transactions 
ER
![image](https://user-images.githubusercontent.com/6285466/87973594-c78c7e80-ca96-11ea-8933-39e55845f083.png)

3. Archive the top tx, no transactions show up on archived txs

ER: 7 transactions disappear
![image](https://user-images.githubusercontent.com/6285466/87973651-d8d58b00-ca96-11ea-9555-f31a02e07253.png)

4. Checkout this branch, check Transactions

ER: 1 archived tx

5. Archive a transaction

ER: Tx list goes down by one, 2 archived transactions
![image](https://user-images.githubusercontent.com/6285466/87973810-15a18200-ca97-11ea-8e9d-05eab30c581d.png)

6. Reload page, unpublished/archived counts are still on.