### PR TITLE
BUGFIX: Wallet details tx keys

### DIFF
--- a/client-admin/src/components/Wallets/YourWallets/WalletDetails/TransactionDetails.jsx
+++ b/client-admin/src/components/Wallets/YourWallets/WalletDetails/TransactionDetails.jsx
@@ -74,7 +74,7 @@ export default function TransactionDetails({
             txDetails.map((txDetails, index) => {
               return (
                 <TransactionDetailsCard
-                  key={txDetails.txid}
+                  key={`txDetails.txid-${index}`}
                   txid={txDetails.txid}
                   timestamp={txDetails.timestamp}
                   address={address}


### PR DESCRIPTION
Adds index to the txid to prevent duplicate keys in the wallet details page.