### PR TITLE
Added weekly prices for BTC

### DIFF
--- a/client-admin/src/components/PriceTracker/Bitcoin/index.jsx
+++ b/client-admin/src/components/PriceTracker/Bitcoin/index.jsx
@@ -126,9 +126,6 @@ export default function BitcoinPriceTracker() {
 
   const getWeekPrices = async () => {
     let res, dayprice, i;
-    //const currentday = new Date();
-    //const prevday = new Date();
-
     
 
     for (i = 0; i < 7; i++)


### PR DESCRIPTION
Now displays past week's BTC prices.