### PR TITLE
change sent to received for startup tx details list

### DIFF
--- a/client-admin/src/ui/Dialog/StartupDetails.jsx
+++ b/client-admin/src/ui/Dialog/StartupDetails.jsx
@@ -154,9 +154,8 @@ export default function StartupDetails(props) {
       console.log(e);
     }
 
-    console.log("accountData");
-    console.log(accountData);
     const { transactions, account } = accountData;
+
     setName(account.name);
     setImage(account.image);
     setCountry(account.country);
@@ -171,7 +170,7 @@ export default function StartupDetails(props) {
     setAddresses(account.addresses);
     setTransactions(
       transactions.filter((tx) => {
-        return tx.sent === true;
+        return tx.received === true;
       })
     );
   };


### PR DESCRIPTION
Fixes a bug in Accounts -> Startups -> View Details

Transactions were set to sent===true which is correct for natcoms. Changed to received === true to show txs they've received from HQ.