### PR TITLE
383 Bugfix Rounding Bottlenecks

### DIFF
--- a/index.js
+++ b/index.js
@@ -534,19 +534,19 @@ class JuniperAdmin {
     );
 
     if (ethBalance.length > 0 && ethBalance[0].balance) {
-      ethBalance = ethBalance[0].balance;
+      ethBalance = utils.roundToFourDecimals(ethBalance[0].balance);
     } else {
       ethBalance = 0;
     }
 
     if (ethSent.length > 0 && ethSent[0].totalSent) {
-      ethSent = ethSent[0].totalSent;
+      ethSent = utils.roundToFourDecimals(ethSent[0].totalSent);
     } else {
       ethSent = 0;
     }
 
     if (ethReceived.length > 0 && ethReceived[0].totalReceived) {
-      ethReceived = ethReceived[0].totalReceived;
+      ethReceived = utils.roundToFourDecimals(ethReceived[0].totalReceived);
     } else {
       ethReceived = 0;
     }
@@ -571,18 +571,18 @@ class JuniperAdmin {
     }
 
     if (btcBalance.length > 0 && btcBalance[0].balance) {
-      btcBalance = btcBalance[0].balance;
+      btcBalance = utils.roundToFourDecimals(btcBalance[0].balance);
     } else {
       btcBalance = 0;
     }
 
     if (btcSent.length > 0 && btcSent[0].totalSent) {
-      btcSent = btcSent[0].totalSent;
+      btcSent = utils.roundToFourDecimals(btcSent[0].totalSent);
     } else {
       btcSent = 0;
     }
     if (btcReceived.length > 0 && btcReceived[0].totalReceived) {
-      btcReceived = btcReceived[0].totalReceived;
+      btcReceived = utils.roundToFourDecimals(btcReceived[0].totalReceived);
     } else {
       btcReceived = 0;
     }
@@ -623,6 +623,36 @@ class JuniperAdmin {
       btcReceivedUSD,
     };
   }
+
+  async getPrices() {
+    let bitcoin = [];
+    let ethereum = [];
+
+    try {
+      this.logger.info("Getting BTC Prices");
+      bitcoin = await this.db.getPrices("BTC");
+
+      bitcoin.forEach((price) => {
+        return this.utils.roundToTwoDecimals(price.average);
+      });
+
+      this.logger.info("Getting ETH Prices");
+      ethereum = await this.db.getPrices("ETH");
+
+      ethereum.forEach((price) => {
+        return this.utils.roundToTwoDecimals(price.average);
+      });
+    } catch (e) {
+      this.logger.error(e);
+      return res.status(500).send();
+    }
+
+    return {
+      bitcoin,
+      ethereum,
+    };
+  }
+
   async getWallets() {
     return await this.db.models.Wallet.find();
   }

--- a/lib/routes/Prices/index.js
+++ b/lib/routes/Prices/index.js
@@ -4,27 +4,23 @@ const logger = new Logger("Price Routes");
 
 router.get("/", async (req, res) => {
   const juniperAdmin = req.app.get("juniperAdmin");
+
   let bitcoin = [];
   let ethereum = [];
 
   let btcPrice = 0;
   let ethPrice = 0;
 
-  try {
-    logger.info("Getting BTC Prices");
-    bitcoin = await juniperAdmin.db.getPrices("BTC");
+  let prices = { bitcoin: [], ethereum: [] };
 
-    logger.info("Getting ETH Prices");
-    ethereum = await juniperAdmin.db.getPrices("ETH");
+  try {
+    prices = await juniperAdmin.getPrices();
   } catch (e) {
     logger.error(e);
     return res.status(500).send();
   }
 
-  res.json({
-    bitcoin,
-    ethereum,
-  });
+  res.json(prices);
 });
 
 module.exports = router;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -32,6 +32,21 @@ function createVerificationCode() {
   return `${Math.random() * 1e18}${Math.random() * 1e18}`;
 }
 
+function roundToNDecimals(decimals) {
+  return function (number) {
+    let pow = Math.pow(10, decimals);
+    return Math.round(number * pow) / pow;
+  };
+}
+
+function roundToFourDecimals(number) {
+  return roundToNDecimals(4)(number);
+}
+
+function roundToTwoDecimals(number) {
+  return roundToNDecimals(2)(number);
+}
+
 module.exports = {
   ...web3Utils,
   debounce,
@@ -39,4 +54,6 @@ module.exports = {
   hash256,
   createSalt,
   createVerificationCode,
+  roundToFourDecimals,
+  roundToTwoDecimals,
 };


### PR DESCRIPTION
ER: Wallets Summary was rounding incorrectly because it was using a non-rounded crypto value and price value. 

AR: Backend will round the prices and crypto values to 2 and 4 places respectively. 

To test: 

1) Wallets Summary page:

USD amounts are the following function: utils.formatUSD(CryptoBalance * DayRate = Amount)

Changes:
Back end will handle rounding with 3 new functions. The front end will continue using the cosmetic formatting that includes the currency Symbol.