### PR TITLE
378 Fix donor/natcom creation form

### DIFF
--- a/client/src/components/organisms/Dialog/CreateAccount.jsx
+++ b/client/src/components/organisms/Dialog/CreateAccount.jsx
@@ -181,14 +181,20 @@ export default function CreatePayee(props) {
   };
 
   const disableSubmit = () => {
-    if (
-      name === null ||
-      name.length === 0 ||
-      country === "" ||
-      description === "" ||
-      weblink === ""
-    ) {
-      return true;
+    if (type === "payee") {
+      if (
+        name === null ||
+        name.length === 0 ||
+        country === "" ||
+        description === "" ||
+        weblink === ""
+      ) {
+        return true;
+      }
+    } else {
+      if (name === null || name.length === 0) {
+        return true;
+      }
     }
 
     for (let i = 0; i < addresses.length; i++) {


### PR DESCRIPTION
Fixes: #378 

ER: Validation will check account type to apply the correction validation and enable form submit button..
AR: Form validation for Donor/Natcom forms is checking for payee-specific fields and disabling the submit button.

To Test:
1. Create a new donor
Huobi
19ZvaaHAaihrWaAT18XVV8odGfZ9PKj31K
Bitcoin

The form is used for all accounts. Repeat above for a Natcom and verify creating payees is unaffected.

ER: Submit button enables when form is complete
AR: Submit button remains disabled
